### PR TITLE
Tweak llm response valid json

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -2,11 +2,6 @@ name: Docker Image CI
 
 on:
   pull_request:
-    types:
-      - edited
-      - opened
-    branches:
-      - "**"
   workflow_dispatch:
     
 jobs:

--- a/internal/pkg/http/handlers.go
+++ b/internal/pkg/http/handlers.go
@@ -84,10 +84,18 @@ func getRecommendation(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	resp := response{
-		Response: recommendation,
+	normalized, err := langchain.NormalizeLLMResponse(r.Context(), recommendation, ollamaLlm)
+	if err != nil {
+		w.Write(formatHttpError(err))
+		return
 	}
-	respBytes, err := json.Marshal(&resp)
+
+	var respStruct []*plex.VideoShort
+	if err := json.Unmarshal([]byte(normalized), &respStruct); err != nil {
+		w.Write(formatHttpError(err))
+		return
+	}
+	respBytes, err := json.Marshal(&respStruct)
 	if err != nil {
 		w.Write(formatHttpError(err))
 		return

--- a/internal/pkg/langchain/generate.go
+++ b/internal/pkg/langchain/generate.go
@@ -13,17 +13,17 @@ func GenerateRecommendation(ctx context.Context, recentlyViewed, fullCollection 
 	log.Println("generating recommendation...")
 	grounding := `Please recommend me up to 3 different movies to watch based on my recent watch
 	history provided here: %+v. Please do not suggest any titles that do not exist in the following 
-	collection: %+v. Do not recommend me any titles that have a content rating exceeding the highest
-	content rating in my recent watch history. I have a child in the family, so take into consideration
-	something a toddler would also enjoy watching. Please provide your recommendation as a json array of
+	collection, and use this data to pull title, summary, and content rating information: %+v. 
+	Do not recommend me any titles that have a content rating exceeding the highest
+	content rating in my recent watch history. Please provide your recommendation as a json array of
 	objects, whose members have this shape:
 	{
 		"title": title,
 		"summary": summary,
 		"content_rating": content_rating
 	}
-	Please do not recomment more than 3 titles. Please do ensure your response is valid json before
-	returning it to me.
+	Please do not recommend more than 3 titles. Please do ensure your response is valid json before
+	returning it to me. If a content rating is not found, generate a rating of "NR" for not rated.
 	`
 
 	recommendation, err := llms.GenerateFromSinglePrompt(ctx, llm, fmt.Sprintf(grounding, recentlyViewed, fullCollection))

--- a/internal/pkg/langchain/validate.go
+++ b/internal/pkg/langchain/validate.go
@@ -1,0 +1,27 @@
+package langchain
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/tmc/langchaingo/llms"
+	"github.com/tmc/langchaingo/llms/ollama"
+)
+
+func NormalizeLLMResponse(ctx context.Context, input string, llm *ollama.LLM) (string, error) {
+	grounding := `
+	Please pretty print the following into valid json. 
+	Do not include any markdown, new lines, or extra whitespace. Please specifically remove any 
+	backticks and markdown indicating this is a json object.
+	Please remove any you find in the provided text: 
+	
+	%s
+	`
+
+	recommendation, err := llms.GenerateFromSinglePrompt(ctx, llm, fmt.Sprintf(grounding, input))
+	if err != nil {
+		return "", err
+	}
+
+	return recommendation, nil
+}


### PR DESCRIPTION
This PR includes a secondary prompt to coerce the generated recommendation output into a list of Plex.VideoShort types. That output is marshalled to json before returning over the wire. 