### PR TITLE
Add id on plex video schema

### DIFF
--- a/backend/internal/pkg/http/handlers.go
+++ b/backend/internal/pkg/http/handlers.go
@@ -4,15 +4,19 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/google/uuid"
+	"github.com/wgeorgecook/plex-recommendation/internal/pkg/plex"
 	"github.com/wgeorgecook/plex-recommendation/internal/pkg/telemetry"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"log"
 	"net/http"
 	"strconv"
-
-	"github.com/wgeorgecook/plex-recommendation/internal/pkg/plex"
 )
+
+type llmResponse struct {
+	Videos        []*plex.VideoShort `json:"videos"`
+	Justification string             `json:"justification"`
+}
 
 func formatHttpError(err error) []byte {
 	return []byte(fmt.Sprintf(`{"error": "%s"}`, err.Error()))
@@ -47,7 +51,7 @@ func recommendationHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	span.AddEvent("recommendation generated")
-	var respStruct []*plex.VideoShort
+	var respStruct *llmResponse
 	if err := json.Unmarshal([]byte(recommendation), &respStruct); err != nil {
 		w.Write(formatHttpError(err))
 		span.SetStatus(codes.Error, err.Error())

--- a/backend/internal/pkg/http/helpers.go
+++ b/backend/internal/pkg/http/helpers.go
@@ -62,7 +62,7 @@ func getRecommendation(ctx context.Context, section string, limit int) (string, 
 	span.AddEvent("embeddings complete")
 	log.Println("embeddings complete, querying database")
 
-	results, err := weaviate.VectorQuery(ctx, weaviate.VideoClass.Class, limit, rvEmbeddings)
+	results, err := weaviate.VectorQuery(ctx, weaviate.VideoClass.Class, rvEmbeddings)
 	if err != nil {
 		span.SetStatus(codes.Error, err.Error())
 		return "", err

--- a/backend/internal/pkg/http/helpers.go
+++ b/backend/internal/pkg/http/helpers.go
@@ -37,7 +37,7 @@ func getRecommendation(ctx context.Context, section string, limit int) (string, 
 
 	// query the cache to see if we've asked for recommendations
 	// based on this exact recently viewed
-	resp, err := pg.QueryData(ctx, pg.WithInputTitles(buildStringFromSlice(titles)))
+	resp, err := pg.QueryData(ctx, pg.WithInputTitles(titles))
 	if err != nil {
 		span.SetStatus(codes.Error, err.Error())
 		log.Println("could not query cache for these titles: ", err.Error())

--- a/backend/internal/pkg/http/helpers.go
+++ b/backend/internal/pkg/http/helpers.go
@@ -52,7 +52,7 @@ func getRecommendation(ctx context.Context, section string, limit int) (string, 
 
 	span.AddEvent("no cached recommendation")
 
-	log.Println("embeding recently viewed...")
+	log.Println("embedding recently viewed...")
 	log.Println("embedding ", len(rvTexts), " texts")
 	rvEmbeddings, err := ollamaEmbedder.CreateEmbedding(ctx, rvTexts)
 	if err != nil {

--- a/backend/internal/pkg/langchain/generate.go
+++ b/backend/internal/pkg/langchain/generate.go
@@ -31,6 +31,22 @@ func GenerateRecommendation(ctx context.Context, recentlyViewed, fullCollection 
 	}
 	Please do not recommend more than 3 titles. Please do ensure your response is valid json before
 	returning it to me. If a content rating is not found, generate a rating of "NR" for not rated.
+
+	Finally, return a justification for why you recommended these titles. This justification should be outside of the
+	array of titles, and be on the "justification" member of the response json. Your final output should take this 
+	shape: 
+	{ 
+		"videos": [
+			{
+				"title": title,
+				"summary": summary,
+				"content_rating": content_rating,
+				"plex_id": plex_id,
+			}
+		], 
+		"justification": "I recommend watching these videos based on your recent watch history because..."
+	}
+	with the "justification" being the actual reason why you recommended those videos based on my recent watch history.
 	`
 
 	recommendation, err := llms.GenerateFromSinglePrompt(ctx, llm, fmt.Sprintf(grounding, recentlyViewed, fullCollection))

--- a/backend/internal/pkg/langchain/generate.go
+++ b/backend/internal/pkg/langchain/generate.go
@@ -26,7 +26,8 @@ func GenerateRecommendation(ctx context.Context, recentlyViewed, fullCollection 
 	{
 		"title": title,
 		"summary": summary,
-		"content_rating": content_rating
+		"content_rating": content_rating,
+		"plex_id": plex_id,
 	}
 	Please do not recommend more than 3 titles. Please do ensure your response is valid json before
 	returning it to me. If a content rating is not found, generate a rating of "NR" for not rated.

--- a/backend/internal/pkg/langchain/validate.go
+++ b/backend/internal/pkg/langchain/validate.go
@@ -22,6 +22,7 @@ func NormalizeLLMResponse(ctx context.Context, input string, llm *ollama.LLM) (s
 	Please remove any you find in the provided text: 
 	
 	%s
+	so that the output is only a valid json object and nothing else.
 	`
 
 	recommendation, err := llms.GenerateFromSinglePrompt(ctx, llm, fmt.Sprintf(grounding, input))

--- a/backend/internal/pkg/pg/client.go
+++ b/backend/internal/pkg/pg/client.go
@@ -2,7 +2,6 @@ package pg
 
 import (
 	"context"
-	b64 "encoding/base64"
 	"github.com/wgeorgecook/plex-recommendation/internal/pkg/telemetry"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
@@ -67,13 +66,14 @@ type queryOption struct {
 
 type QueryOption func(*queryOption)
 
-func WithInputTitles(i string) QueryOption {
+func WithInputTitles(i []string) QueryOption {
 	return func(q *queryOption) {
-		q.input = b64.StdEncoding.EncodeToString([]byte(i))
+		slices.Sort(i)
+		q.input = toBase64(buildStringFromSlice(i))
 	}
 }
 
-func WithReponse(r string) QueryOption {
+func WithResponse(r string) QueryOption {
 	return func(q *queryOption) {
 		q.response = r
 	}

--- a/backend/internal/pkg/pg/client_test.go
+++ b/backend/internal/pkg/pg/client_test.go
@@ -6,7 +6,13 @@ import (
 )
 
 func TestQueryOptions(t *testing.T) {
-	// Written entirely with Gemini
+	// Written mostly with Gemini
+	var (
+		testTitles    = []string{"test", "title"}
+		anotherTitle  = []string{"another", "title"}
+		stringTitles  = buildStringFromSlice(testTitles)
+		anotherString = buildStringFromSlice(anotherTitle)
+	)
 	tests := []struct {
 		name     string
 		options  []QueryOption
@@ -19,18 +25,18 @@ func TestQueryOptions(t *testing.T) {
 		},
 		{
 			name:     "With Input Title",
-			options:  []QueryOption{WithInputTitles("test title")},
-			expected: queryOption{response: "", input: base64.StdEncoding.EncodeToString([]byte("test title"))},
+			options:  []QueryOption{WithInputTitles(testTitles)},
+			expected: queryOption{response: "", input: base64.StdEncoding.EncodeToString([]byte(stringTitles))},
 		},
 		{
 			name:     "With Response",
-			options:  []QueryOption{WithReponse("data")},
+			options:  []QueryOption{WithResponse("data")},
 			expected: queryOption{response: "data", input: ""},
 		},
 		{
 			name:     "With Both Options",
-			options:  []QueryOption{WithInputTitles("another title"), WithReponse("result")},
-			expected: queryOption{response: "result", input: base64.StdEncoding.EncodeToString([]byte("another title"))},
+			options:  []QueryOption{WithInputTitles(anotherTitle), WithResponse("result")},
+			expected: queryOption{response: "result", input: base64.StdEncoding.EncodeToString([]byte(anotherString))},
 		},
 	}
 

--- a/backend/internal/pkg/plex/api.go
+++ b/backend/internal/pkg/plex/api.go
@@ -42,10 +42,14 @@ type VideoShort struct {
 	Title         string `json:"title"`
 	Summary       string `json:"summary"`
 	ContentRating string `json:"content_rating"`
+	PlexID        string `json:"plex_id"`
 }
 
 func (v VideoShort) String() string {
-	return "Title: " + v.Title + "\nSummary: " + v.Summary + "\nContent Rating: " + v.ContentRating
+	return "Title: " + v.Title +
+		"\nSummary: " + v.Summary +
+		"\nContent Rating: " + v.ContentRating +
+		"\nPlex ID: " + v.PlexID
 }
 
 func fullToShort(vids []Video, limit int) []VideoShort {
@@ -54,7 +58,12 @@ func fullToShort(vids []Video, limit int) []VideoShort {
 		if i >= limit {
 			break
 		}
-		shorts = append(shorts, VideoShort{Title: vid.Title, Summary: vid.Summary, ContentRating: vid.ContentRating})
+		shorts = append(shorts, VideoShort{
+			Title:         vid.Title,
+			Summary:       vid.Summary,
+			ContentRating: vid.ContentRating,
+			PlexID:        vid.Guid,
+		})
 	}
 
 	return shorts

--- a/backend/internal/pkg/plex/api.go
+++ b/backend/internal/pkg/plex/api.go
@@ -116,7 +116,7 @@ func GetAllVideos(ctx context.Context, c Client, sectionId string) ([]VideoShort
 	log.Println("connected")
 	span.AddEvent("connected to plex")
 
-	log.Println("getting recently watched...")
+	log.Println("getting all videos...")
 	resp, err := c.MakeNetworkRequest(ctx, connectionUri, http.MethodGet)
 	if err != nil {
 		span.RecordError(err)

--- a/backend/internal/pkg/weaviate/client.go
+++ b/backend/internal/pkg/weaviate/client.go
@@ -257,7 +257,7 @@ func insertPlexMedia(ctx context.Context, c plex.Client, embedder *ollama.LLM) e
 	return nil
 }
 
-func VectorQuery(ctx context.Context, collectionName string, limit int, vectors [][]float32) ([]*plex.VideoShort, error) {
+func VectorQuery(ctx context.Context, collectionName string, vectors [][]float32) ([]*plex.VideoShort, error) {
 	ctx, span := telemetry.StartSpan(ctx, telemetry.WithSpanName("Vector Query"))
 	defer span.End()
 	span.SetAttributes(attribute.String("package", "weaviate"))
@@ -271,7 +271,7 @@ func VectorQuery(ctx context.Context, collectionName string, limit int, vectors 
 		{Name: "content_rating"},
 		{Name: "plex_id"},
 	}
-	resp, err := client.GraphQL().Get().WithClassName(collectionName).WithFields(fields...).WithNearVector(nearVectorArgument).WithLimit(limit).Do(ctx)
+	resp, err := client.GraphQL().Get().WithClassName(collectionName).WithFields(fields...).WithNearVector(nearVectorArgument).Do(ctx)
 	if err != nil {
 		span.RecordError(err)
 		return nil, err

--- a/backend/internal/pkg/weaviate/client.go
+++ b/backend/internal/pkg/weaviate/client.go
@@ -269,6 +269,7 @@ func VectorQuery(ctx context.Context, collectionName string, limit int, vectors 
 		{Name: "title"},
 		{Name: "summary"},
 		{Name: "content_rating"},
+		{Name: "plex_id"},
 	}
 	resp, err := client.GraphQL().Get().WithClassName(collectionName).WithFields(fields...).WithNearVector(nearVectorArgument).WithLimit(limit).Do(ctx)
 	if err != nil {

--- a/backend/internal/pkg/weaviate/schema.go
+++ b/backend/internal/pkg/weaviate/schema.go
@@ -33,6 +33,11 @@ var VideoClass = models.Class{
 			Description: "motion picture film association content rating",
 			DataType:    []string{"text"},
 		},
+		{
+			Name:        "plex_id",
+			Description: "Plex GUID associated to the video",
+			DataType:    []string{"text"},
+		},
 	},
 }
 


### PR DESCRIPTION
Scope creeped this a little bit to include a justification on the response from the LLM alongside the plex IDs 