### PR TITLE
Set default plex library in environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,13 @@ I run Plex on a Synology NAS using Package Center, so I found mine in
 
 Provide both of these to the `PLEX_ADDRESS` and `PLEX_TOKEN` environment variables.
 
+### Migrating Data 
+On initial boot, the system will detect if your Plex library is stored in the vector
+database. If it is not, your media will be retreived. You need to provide the default
+library to download media from via the `PLEX_DEFAULT_LIBRARY_SECTION` environment 
+variable. You will need to query Plex yourself to get this, but for me, my movies are
+in section 3. I will fall back to this section if you do not provide one.
+
 ## Connecting to your LLM
 This recommendation engine connects to Ollama. You can bring your own or 
 run it on the cloud. Just provide `OLLAMA_ADDRESS`, `OLLAMA_EMBEDDING_MODEL`, and `OLLAMA_LANGUAGE_MODEL` as 

--- a/backend/internal/pkg/config/config.go
+++ b/backend/internal/pkg/config/config.go
@@ -10,8 +10,9 @@ import (
 
 type Config struct {
 	Plex struct {
-		Token   string
-		Address string
+		Token                 string
+		Address               string
+		DefaultLibrarySection string
 	}
 	Ollama struct {
 		Address        string
@@ -38,6 +39,13 @@ func LoadConfig() *Config {
 	}
 	if os.Getenv("PLEX_ADDRESS") != "" {
 		cfg.Plex.Address = os.Getenv("PLEX_ADDRESS")
+	}
+
+	// My movies library is at section 3, so I have the default set to that if
+	// not provided via environment.
+	cfg.Plex.DefaultLibrarySection = "3"
+	if os.Getenv("PLEX_DEFAULT_LIBRARY_SECTION") != "" {
+		cfg.Plex.DefaultLibrarySection = os.Getenv("PLEX_DEFAULT_LIBRARY_SECTION")
 	}
 	if os.Getenv("OLLAMA_ADDRESS") != "" {
 		cfg.Ollama.Address = os.Getenv("OLLAMA_ADDRESS")

--- a/backend/internal/pkg/http/server.go
+++ b/backend/internal/pkg/http/server.go
@@ -2,11 +2,12 @@ package httpinternal
 
 import (
 	"context"
+	"log"
+	"net/http"
+
 	"github.com/wgeorgecook/plex-recommendation/internal/pkg/telemetry"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.opentelemetry.io/otel/codes"
-	"log"
-	"net/http"
 
 	"github.com/tmc/langchaingo/llms/ollama"
 	"github.com/wgeorgecook/plex-recommendation/internal/pkg/config"

--- a/backend/internal/pkg/plex/api.go
+++ b/backend/internal/pkg/plex/api.go
@@ -73,7 +73,7 @@ func GetRecentlyPlayed(ctx context.Context, c Client, sectionId string, limit in
 	ctx, span := telemetry.StartSpan(ctx, telemetry.WithSpanName("GetRecentlyPlayed"))
 	defer span.End()
 	log.Println("connecting to Plex...")
-	connectionUri := c.Connect(sectionId, !allMovies)
+	connectionUri := c.Connect(WithSectionID(sectionId))
 	log.Println("connected")
 	span.AddEvent("connected to Plex")
 
@@ -106,13 +106,14 @@ func GetRecentlyPlayed(ctx context.Context, c Client, sectionId string, limit in
 	return shorts, nil
 }
 
+
 func GetAllVideos(ctx context.Context, c Client, sectionId string) ([]VideoShort, error) {
 	ctx, span := telemetry.StartSpan(ctx, telemetry.WithSpanName("GetAllVideos"))
 	defer span.End()
 
 	span.SetAttributes(attribute.String("package", "plex"))
 	log.Println("connecting to Plex...")
-	connectionUri := c.Connect(sectionId, allMovies)
+	connectionUri := c.Connect(WithSectionID(sectionId), WithAllMovies(allMovies))
 	log.Println("connected")
 	span.AddEvent("connected to plex")
 

--- a/backend/internal/pkg/plex/client_test.go
+++ b/backend/internal/pkg/plex/client_test.go
@@ -39,7 +39,7 @@ func TestPlexClientConnect(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			actualURL := testClient.Connect(tc.sectionID, tc.allMovies)
+			actualURL := testClient.Connect(WithSectionID(tc.sectionID), WithAllMovies(tc.allMovies))
 			if actualURL != tc.expectedURL {
 				t.Errorf("URL mismatch for %s: expected %s, got %s", tc.name, tc.expectedURL, actualURL)
 			}

--- a/backend/internal/pkg/weaviate/client.go
+++ b/backend/internal/pkg/weaviate/client.go
@@ -5,11 +5,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log"
+	"strings"
+
 	"github.com/wgeorgecook/plex-recommendation/internal/pkg/telemetry"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
-	"log"
-	"strings"
 
 	"github.com/go-openapi/strfmt"
 	"github.com/tmc/langchaingo/llms/ollama"
@@ -207,7 +208,7 @@ func insertPlexMedia(ctx context.Context, c plex.Client, embedder *ollama.LLM) e
 	log.Println("performing migration on load...")
 	ctx, span := telemetry.StartSpan(ctx, telemetry.WithSpanName("Insert Plex Media"))
 	defer span.End()
-	vids, err := plex.GetAllVideos(ctx, c, "3")
+	vids, err := plex.GetAllVideos(ctx, c, c.GetDefaultLibrarySection())
 	if err != nil {
 		span.RecordError(err)
 		return err


### PR DESCRIPTION
Support reading `PLEX_DEFAULT_LIBRARY_SECTION` in the environment for loading media on boot. 